### PR TITLE
Updated broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You decide that one of you **(Programmer 1) will resolve issue number 1** while 
 <!-- ***********************************************************-->
 ## Step 8 - Both programmers commit their changes
 
-1. Both programmers [commit](http://stackoverflow.com/questions/27˜Ω45076/what-are-the-differences-between-git-commit-and-git-push) the changes. Before closing the commit message with a quote symbol you can press enter on your keyboard to continue typing in the new terminal line. The text in the second line can be used as an additional message. It is a good practice to link your commit to an existing issue by typing  `Relates #1`. Thanks to using the hash symbol followed by the relevant issue number your commit will be [automatically linked to an existing issue](https://help.github.com/articles/autolinked-references-and-urls/).
+1. Both programmers [commit](https://stackoverflow.com/questions/2745076/what-are-the-differences-between-git-commit-and-git-push) the changes. Before closing the commit message with a quote symbol you can press enter on your keyboard to continue typing in the new terminal line. The text in the second line can be used as an additional message. It is a good practice to link your commit to an existing issue by typing  `Relates #1`. Thanks to using the hash symbol followed by the relevant issue number your commit will be [automatically linked to an existing issue](https://help.github.com/articles/autolinked-references-and-urls/).
 
   ```sh
   # Programmer 1:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An exercise to practice git workflow skills. The workshop should be undertaken b
 <!-- ***********************************************************-->
 ## OK, let's start :rocket:
 
-Your client has just called you and asked to improve heading on their [company website](https://piotrberebecki.github.io/git-workflow-workshop-for-two/).
+Your client has just called you and asked you to improve the heading on their [company website](https://foundersandcoders.github.io/git-workflow-workshop-for-two/).
 
 There are two issues that when resolved will make the heading look really nice:
 


### PR DESCRIPTION
There were 2 broken links in the readme:
- The live website of the repository
- Link to stackoverflow question on difference between git commit and git push